### PR TITLE
Pass $ID to getPort.sh, added check for existing port allocation

### DIFF
--- a/deployTestInstance.sh
+++ b/deployTestInstance.sh
@@ -172,7 +172,7 @@ echo "Backend environment variables configured"
 lockfile -5 ~/deployTestInstance.lock
 
 # Collect a port
-PORT="$(bash ~/CI-CD/getPort.sh)"
+PORT="$(bash ~/CI-CD/getPort.sh "$ID")"
 
 # Make sure the port isn't 0
 if [ "${PORT}" -eq "0" ]; then

--- a/getPort.sh
+++ b/getPort.sh
@@ -3,8 +3,8 @@
 ########################################################################################
 # This script is designed to be called with no arguments, and return a port that is    #
 # currently unused, and allocate it so that concurrent runs hopefully don't take it.   #
-# This isn't perfectly thread-safe, but it should be close enough that we likely will  #
-# never run into any issues (sorry future folks if it does ever happen)                #
+# This isn't perfectly multi-access safe, but it should be close enough that we likely #
+# will never run into any issues (sorry future folks if it does ever happen)           #
 ########################################################################################
 
 # Ranges are inclusive
@@ -20,7 +20,11 @@ CHOSENPORT=0
 for ((PORT=PORT_RANGE_START; PORT<PORT_RANGE_END; PORT++))
 do
   if [[ ! -f "$FOLDER/$PORT" ]]; then
-    # Found an open port to use
+    # File does not exist, therefore we found an open port to use
+    CHOSENPORT=$PORT
+    break
+  elif [[ "$(cat "$FOLDER/$PORT")" == "$1" ]]; then
+    # File contents have the ID that we are currently getting a port for, reuse that port
     CHOSENPORT=$PORT
     break
   fi

--- a/getPort.sh
+++ b/getPort.sh
@@ -23,7 +23,7 @@ do
     # File does not exist, therefore we found an open port to use
     CHOSENPORT=$PORT
     break
-  elif [[ "$(cat "$FOLDER/$PORT")" == "$1" ]]; then
+  elif [[ $# -ne 0 ]] && [[ "$(cat "$FOLDER/$PORT")" == "$1" ]]; then
     # File contents have the ID that we are currently getting a port for, reuse that port
     CHOSENPORT=$PORT
     break


### PR DESCRIPTION
Fix for #14, essentially just modifies `getPort.sh` to check for existing port allocations via a new argument (`$1`) being passed in from the `deployTestInstance.sh`, and then modifies `deployTestInstance.sh` to actually send that argument when calling the script. If `getPort.sh` finds that ID already has a port, it returns it so it can be reused by `deployTestInstance.sh`. 